### PR TITLE
CP Control Hotkeys

### DIFF
--- a/WpfApp3/HCM.csproj
+++ b/WpfApp3/HCM.csproj
@@ -83,6 +83,7 @@
     <Compile Include="AboutWindow.xaml.cs">
       <DependentUpon>AboutWindow.xaml</DependentUpon>
     </Compile>
+    <Compile Include="HCMHotkeys.cs" />
     <Compile Include="SettingsWindow.xaml.cs">
       <DependentUpon>SettingsWindow.xaml</DependentUpon>
     </Compile>

--- a/WpfApp3/HCMHotkeys.cs
+++ b/WpfApp3/HCMHotkeys.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Mime;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Windows;
+using System.Windows.Forms;
+using System.Windows.Input;
+using System.Windows.Interop;
+
+namespace HCMHotkeys
+{
+    public sealed class KeyboardHook : IDisposable
+    {
+        // Registers a hot key with Windows.
+        [DllImport("user32.dll")]
+        private static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
+        // Unregisters the hot key with Windows.
+        [DllImport("user32.dll")]
+        private static extern bool UnregisterHotKey(IntPtr hWnd, int id);
+
+        /// <summary>
+        /// Represents the window that is used internally to get the messages.
+        /// </summary>
+        private class Window : NativeWindow, IDisposable
+        {
+            private static int WM_HOTKEY = 0x0312;
+
+            public Window()
+            {
+                // create the handle for the window.
+                this.CreateHandle(new CreateParams());
+            }
+
+            /// <summary>
+            /// Overridden to get the notifications.
+            /// </summary>
+            /// <param name="m"></param>
+            protected override void WndProc(ref Message m)
+            {
+                base.WndProc(ref m);
+
+                // check if we got a hot key pressed.
+                if (m.Msg == WM_HOTKEY)
+                {
+                    // get the keys.
+                    Keys key = (Keys)(((int)m.LParam >> 16) & 0xFFFF);
+                    ModifierKeys modifier = (ModifierKeys)((int)m.LParam & 0xFFFF);
+
+                    // invoke the event to notify the parent.
+                    if (KeyPressed != null)
+                        KeyPressed(this, new KeyPressedEventArgs(modifier, key));
+                }
+            }
+
+            public event EventHandler<KeyPressedEventArgs> KeyPressed;
+
+            #region IDisposable Members
+
+            public void Dispose()
+            {
+                this.DestroyHandle();
+            }
+
+            #endregion
+        }
+
+        private Window _window = new Window();
+        private int _currentId;
+
+        public KeyboardHook()
+        {
+            // register the event of the inner native window.
+            _window.KeyPressed += delegate (object sender, KeyPressedEventArgs args)
+            {
+                if (KeyPressed != null)
+                    KeyPressed(this, args);
+            };
+        }
+
+        /// <summary>
+        /// Registers a hot key in the system.
+        /// </summary>
+        /// <param name="modifier">The modifiers that are associated with the hot key.</param>
+        /// <param name="key">The key itself that is associated with the hot key.</param>
+        public void RegisterHotKey(ModifierKeys modifier, Keys key)
+        {
+
+            // register the hot key.
+            if (!RegisterHotKey(_window.Handle, 0, (uint)modifier, (uint)key))
+                throw new InvalidOperationException("Couldn’t register the hot key.");
+        }
+
+        public void UnregisterAllHotKeys()
+        {
+            UnregisterHotKey(_window.Handle, 0);
+
+        }
+
+        /// <summary>
+        /// A hot key has been pressed.
+        /// </summary>
+        public event EventHandler<KeyPressedEventArgs> KeyPressed;
+
+        #region IDisposable Members
+
+        public void Dispose()
+        {
+           UnregisterHotKey(_window.Handle, 0);
+
+            // dispose the inner native window.
+            _window.Dispose();
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Event Args for the event that is fired after the hot key has been pressed.
+    /// </summary>
+    public class KeyPressedEventArgs : EventArgs
+    {
+        private ModifierKeys _modifier;
+        private Keys _key;
+
+        internal KeyPressedEventArgs(ModifierKeys modifier, Keys key)
+        {
+            _modifier = modifier;
+            _key = key;
+        }
+
+        public ModifierKeys Modifier
+        {
+            get { return _modifier; }
+        }
+
+        public Keys Key
+        {
+            get { return _key; }
+        }
+    }
+
+    /// <summary>
+    /// The enumeration of possible modifiers.
+    /// </summary>
+    [Flags]
+    public enum ModifierKeys : uint
+    {
+        None = 0,
+        Alt = 1,
+        Control = 2,
+        Shift = 4,
+        Win = 8
+    }
+
+}

--- a/WpfApp3/SettingsWindow.xaml
+++ b/WpfApp3/SettingsWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:local="clr-namespace:WpfApp3"
         mc:Ignorable="d"
         Title="Settings" Height="266.013" Width="400" WindowStyle="None">
-    <Grid>
+    <Grid Height="258" VerticalAlignment="Top">
 
         <RadioButton  x:Name ="modeanni"  Content="Anniversary" HorizontalAlignment="Left" Margin="146,64,0,0" VerticalAlignment="Top" />
         <RadioButton  x:Name ="modeclas"  Content="Classic" HorizontalAlignment="Left" Margin="51,64,0,0" VerticalAlignment="Top" IsChecked="True"/>
@@ -16,6 +16,13 @@
         <CheckBox x:Name="LevelLockoutCheckbox" Content="Lockout Injection when on Wrong Level" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="21,170,0,0" IsChecked="true"/>
         <ComboBox x:Name="LevelListBox" HorizontalAlignment="Left" Height="28" Margin="146,103,0,0" VerticalAlignment="Top" Width="86"/>
         <Label Content="Display Level List as: " HorizontalAlignment="Left" Height="31" Margin="21,103,0,0" VerticalAlignment="Top" Width="143"/>
+        <Label Content="CP Hotkey:" HorizontalAlignment="Left" Height="25" Margin="255,39,0,0" VerticalAlignment="Top" Width="127"/>
+        <Label Content="Revert Hotkey:" HorizontalAlignment="Left" Height="25" Margin="255,88,0,0" VerticalAlignment="Top" Width="127"/>
+        <Label Content="2x Revert Hotkey:" HorizontalAlignment="Left" Height="25" Margin="255,137,0,0" VerticalAlignment="Top" Width="127"/>
+        <Button Name="CPHotkey" Content="&lt;No Key>" HorizontalAlignment="Left" Height="24" Margin="255,64,0,0" VerticalAlignment="Top" Width="127" Click="CPHotkey_Click"/>
+        <Button Name="RevertHotkey" Content="&lt;No Key>" HorizontalAlignment="Left" Height="24" Margin="255,113,0,0" VerticalAlignment="Top" Width="127" Click="RevertHotkey_Click"/>
+        <Button Name="DoubleRevertHotkey" Content="&lt;No Key>" HorizontalAlignment="Left" Height="24" Margin="255,162,0,0" VerticalAlignment="Top" Width="127" Click="DoubleRevertHotkey_Click"/>
+        <Label Content="(Escape to unbind)" HorizontalAlignment="Center" Height="25" Margin="257,187,8,0" VerticalAlignment="Top" Width="127"/>
 
 
 

--- a/WpfApp3/SettingsWindow.xaml.cs
+++ b/WpfApp3/SettingsWindow.xaml.cs
@@ -1,22 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
-using System.IO;
-using System.Reflection;
-using Microsoft.VisualBasic;
-
-using System.Windows.Forms;
+using HCMHotkeys;
 
 namespace WpfApp3
 {
@@ -25,15 +10,17 @@ namespace WpfApp3
     /// </summary>
     public partial class SettingsWindow : Window
     {
+        public MainWindow.HCMConfig Config = MainWindow.HCMGlobal.SavedConfig;
+        public KeyboardHook CPHotkeyHook = MainWindow.CPHotkeyHook;
+        public KeyboardHook RevertHotkeyHook = MainWindow.RevertHotkeyHook;
+        public KeyboardHook DoubleRevertHotkeyHook = MainWindow.DoubleRevertHotkeyHook;
 
         public SettingsWindow()
         {
             InitializeComponent();
-
-
-
-
-
+            CPHotkey.Content = Config.CPHotkey.ToString() ?? "$lt;No Key>";
+            RevertHotkey.Content = Config.RevertHotkey.ToString() ?? "$lt;No Key>";
+            DoubleRevertHotkey.Content = Config.DoubleRevertHotkey.ToString() ?? "$lt;No Key>";
         }
 
         private void CloseButton_Click(object sender, RoutedEventArgs e)
@@ -41,6 +28,102 @@ namespace WpfApp3
             Close();
         }
 
+        
+        System.Windows.Controls.Button currentButton;
 
+        void SetCPHotkey(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            CPHotkeyHook.Dispose();
+            if (e.Key == Key.Escape) {
+                Config.CPHotkey = Key.None;
+                currentButton.Content = Config.CPHotkey.ToString() ?? "&lt;No Key>";
+                currentButton = null;
+                KeyDown -= SetCPHotkey;
+                return;
+            }
+            
+            Config.CPHotkey = e.Key;
+            currentButton.Content = e.Key.ToString();
+            currentButton = null;
+            KeyDown -= SetCPHotkey;
+
+            CPHotkeyHook.Dispose();
+
+            CPHotkeyHook = new KeyboardHook();
+            CPHotkeyHook.KeyPressed += new EventHandler<KeyPressedEventArgs>(MainWindow.ForceCP);
+            CPHotkeyHook.RegisterHotKey(HCMHotkeys.ModifierKeys.None, (System.Windows.Forms.Keys)KeyInterop.VirtualKeyFromKey(e.Key));
+            return;
+        }
+
+        void SetRevertHotkey(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            RevertHotkeyHook.Dispose();
+            if (e.Key == Key.Escape)
+            {
+                Config.RevertHotkey = Key.None;
+                currentButton.Content = Config.RevertHotkey.ToString() ?? "&lt;No Key>";
+                currentButton = null;
+                KeyDown -= SetRevertHotkey;
+                return;
+            }
+
+            Config.RevertHotkey = e.Key;
+            currentButton.Content = e.Key.ToString();
+            currentButton = null;
+            KeyDown -= SetRevertHotkey;
+
+            RevertHotkeyHook.Dispose();
+
+            RevertHotkeyHook = new KeyboardHook();
+            RevertHotkeyHook.KeyPressed += new EventHandler<KeyPressedEventArgs>(MainWindow.ForceRevert);
+            RevertHotkeyHook.RegisterHotKey(HCMHotkeys.ModifierKeys.None, (System.Windows.Forms.Keys)KeyInterop.VirtualKeyFromKey(e.Key));
+            return;
+        }
+
+        void SetDoubleRevertHotkey(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            DoubleRevertHotkeyHook.Dispose();
+            if (e.Key == Key.Escape)
+            {
+                Config.DoubleRevertHotkey = Key.None;
+                currentButton.Content = Config.DoubleRevertHotkey.ToString() ?? "&lt;No Key>";
+                currentButton = null;
+                KeyDown -= SetDoubleRevertHotkey;
+                return;
+            }
+
+            Config.DoubleRevertHotkey = e.Key;
+            currentButton.Content = e.Key.ToString();
+            currentButton = null;
+            KeyDown -= SetDoubleRevertHotkey;
+
+            DoubleRevertHotkeyHook.Dispose();
+
+            DoubleRevertHotkeyHook = new KeyboardHook();
+            DoubleRevertHotkeyHook.KeyPressed += new EventHandler<KeyPressedEventArgs>(MainWindow.ForceDoubleRevert);
+            DoubleRevertHotkeyHook.RegisterHotKey(HCMHotkeys.ModifierKeys.None, (System.Windows.Forms.Keys)KeyInterop.VirtualKeyFromKey(e.Key));
+            return;
+        }
+
+        private void CPHotkey_Click(object sender, RoutedEventArgs e)
+        {
+            CPHotkey.Content = "...";
+            currentButton = (System.Windows.Controls.Button)sender;
+            KeyDown += SetCPHotkey;
+        }
+
+        private void RevertHotkey_Click (object sender, RoutedEventArgs e)
+        {
+            RevertHotkey.Content = "...";
+            currentButton = (System.Windows.Controls.Button)sender;
+            KeyDown += SetRevertHotkey;
+        }
+
+        private void DoubleRevertHotkey_Click (object sender, RoutedEventArgs e)
+        {
+            DoubleRevertHotkey.Content = "...";
+            currentButton = (System.Windows.Controls.Button)sender;
+            KeyDown += SetDoubleRevertHotkey;
+        }
     }
 }


### PR DESCRIPTION
In case people don't want to download trainers (especially since they don't automatically update), this PR will allow HCM users to force checkpoint, revert, or double revert in a fashion similar to the CP trainers, all in one application and using the built-in HCM functions to (as I understand it) support automatic updates.

![image](https://user-images.githubusercontent.com/5671812/124896754-900e2f00-df92-11eb-9348-95e6d47390f6.png)

_Buttons save to config and are by default unbound. Simply click on the button to set a bind, and press escape to unbind._

Features added:
* Added hotkeys for checkpoint/revert/double revert.
* Added keybind selectors for checkpoint/revert/double revert to settings window.

Other changes:
* Removed unnecessary sender and eventargs params from checkpoint/revert/double revert functions.