### PR TITLE
remember sort settings when reopening sort dialog

### DIFF
--- a/WpfApp3/HCM.csproj
+++ b/WpfApp3/HCM.csproj
@@ -83,6 +83,7 @@
     <Compile Include="AboutWindow.xaml.cs">
       <DependentUpon>AboutWindow.xaml</DependentUpon>
     </Compile>
+    <Compile Include="HCMConfig.cs" />
     <Compile Include="HCMHotkeys.cs" />
     <Compile Include="SettingsWindow.xaml.cs">
       <DependentUpon>SettingsWindow.xaml</DependentUpon>

--- a/WpfApp3/HCMConfig.cs
+++ b/WpfApp3/HCMConfig.cs
@@ -1,0 +1,55 @@
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Input;
+
+namespace WpfApp3 {
+    public class HCMConfig
+    {
+        public string[] RanVersions;
+        //public string CoreFolderPath;
+        public bool ClassicMode = true;
+        public int Reset_Tab;
+        public int[] Reset_Folder;
+        public int[] Reset_SelCP;
+        public double[] Reset_Col;
+        public bool LockoutLevels = true;
+        public int LevelListOption = 0;
+
+        public Key CPHotkey = Key.None;
+        public Key RevertHotkey = Key.None;
+        public Key DoubleRevertHotkey = Key.None;
+
+        public SortConfig Sort = new SortConfig();
+
+        public class SortConfig
+        {
+            [JsonProperty] // serialise even though private
+            private List<(int Key, bool Reverse)> Criteria;
+            public bool ReversePreviousPosition;
+
+            public (int, bool) this[int i]
+            {
+                get
+                {
+                    // default to (None, not reverse)
+                    if (Criteria == null || i >= Criteria.Count)
+                        return (0, false);
+                    return Criteria[i];
+                }
+                set
+                {
+                    // default to (None, not reverse)
+                    while (i >= Criteria.Count)
+                        Criteria.Add((0, false));
+                    Criteria[i] = value;
+                }
+            }
+
+            public void SetCriteria((int, bool)[] criteria)
+            {
+                Criteria = criteria.ToList();
+            }
+        }
+    }
+}

--- a/WpfApp3/MainWindow.xaml.cs
+++ b/WpfApp3/MainWindow.xaml.cs
@@ -136,23 +136,6 @@ namespace WpfApp3
         const int PROCESS_WM_READ = 0x0010;
         const int PROCESS_ALL_ACCESS = 0x1F0FFF;
 
-        public class HCMConfig
-        {
-            public string[] RanVersions;
-            //public string CoreFolderPath;
-            public bool ClassicMode = true;
-            public int Reset_Tab;
-            public int[] Reset_Folder;
-            public int[] Reset_SelCP;
-            public double[] Reset_Col;
-            public bool LockoutLevels = true;
-            public int LevelListOption = 0;
-
-            public Key CPHotkey = Key.None;
-            public Key RevertHotkey = Key.None;
-            public Key DoubleRevertHotkey = Key.None;
-        }
-
         public static class HCMGlobal
         {
             public static readonly string HCMversion = "0.9.7";
@@ -1214,7 +1197,7 @@ namespace WpfApp3
             }
 
             Debug("hmm: " + savepath);
-            SortSavesWindow SortSavesWindow = new SortSavesWindow(savepath.Substring(savepath.LastIndexOf("saves") + 5));
+            SortSavesWindow SortSavesWindow = new SortSavesWindow(savepath.Substring(savepath.LastIndexOf("saves") + 5), ref HCMGlobal.SavedConfig);
             bool? whatbutton = SortSavesWindow.ShowDialog();
 
             //need to check for cancel click in sortsaveswindow
@@ -1228,8 +1211,9 @@ namespace WpfApp3
             //3 = Alphabetically
             //4 = Time into level
 
-            int[] sortoptions = { SortSavesWindow.ReturnSort1, SortSavesWindow.ReturnSort2, SortSavesWindow.ReturnSort3, SortSavesWindow.ReturnSort4 };
-            bool[] reverseoptions = { SortSavesWindow.ReturnReverse1, SortSavesWindow.ReturnReverse2, SortSavesWindow.ReturnReverse3, SortSavesWindow.ReturnReverse4, SortSavesWindow.ReturnReverse5 };
+            (int, bool)[] criteria = SortSavesWindow.Criteria();
+            HCMGlobal.SavedConfig.Sort.SetCriteria(criteria);
+            HCMGlobal.SavedConfig.Sort.ReversePreviousPosition = SortSavesWindow.ReversePreviousPosition();
 
 
 
@@ -1277,7 +1261,7 @@ namespace WpfApp3
 
             //let's do shit in reverse order basically
 
-            if (reverseoptions[4])
+            if (SortSavesWindow.ReversePreviousPosition())
             {
                 Debug("Yes, REVERSING");
                 SortList = SortList.OrderBy(x => x.LastWriteTime)
@@ -1359,10 +1343,8 @@ namespace WpfApp3
             }
 
             //now let's call it
-            SortThisGuyOut(sortoptions[3], reverseoptions[3]);
-            SortThisGuyOut(sortoptions[2], reverseoptions[2]);
-            SortThisGuyOut(sortoptions[1], reverseoptions[1]);
-            SortThisGuyOut(sortoptions[0], reverseoptions[0]);
+            foreach (var (key, reverse) in criteria.Reverse())
+                SortThisGuyOut(key, reverse);
 
 
 

--- a/WpfApp3/SettingsWindow.xaml.cs
+++ b/WpfApp3/SettingsWindow.xaml.cs
@@ -10,7 +10,7 @@ namespace WpfApp3
     /// </summary>
     public partial class SettingsWindow : Window
     {
-        public MainWindow.HCMConfig Config = MainWindow.HCMGlobal.SavedConfig;
+        public HCMConfig Config = MainWindow.HCMGlobal.SavedConfig;
         public KeyboardHook CPHotkeyHook = MainWindow.CPHotkeyHook;
         public KeyboardHook RevertHotkeyHook = MainWindow.RevertHotkeyHook;
         public KeyboardHook DoubleRevertHotkeyHook = MainWindow.DoubleRevertHotkeyHook;

--- a/WpfApp3/SortSavesWindow.xaml.cs
+++ b/WpfApp3/SortSavesWindow.xaml.cs
@@ -19,36 +19,37 @@ namespace WpfApp3
     /// </summary>
     public partial class SortSavesWindow : Window
     {
-        public SortSavesWindow(string savepath)
+        (ComboBox Key, CheckBox Reverse)[] SortFields;
+
+        public SortSavesWindow(string savepath, ref HCMConfig config)
         {
             
             InitializeComponent();
+            SortFields = new[] { (Sort1, Reverse1), (Sort2, Reverse2), (Sort3, Reverse3), (Sort4, Reverse4) };
+
             MainLabel.Content = "Sort Saves in " + savepath;
             string[] sortoptions = { "None", "Difficulty", "Level Name", "File Name", "Time into Level" };
-            foreach (string option in sortoptions)
+            foreach (var (field, i) in SortFields.Select((x, i) => (x, i)))
             {
-                Sort1.Items.Add(option);
-                Sort2.Items.Add(option);
-                Sort3.Items.Add(option);
-                Sort4.Items.Add(option);
+                foreach (string option in sortoptions)
+                    field.Key.Items.Add(option);
+                field.Key.SelectedIndex = config.Sort[i].Item1;
+                field.Reverse.IsChecked = config.Sort[i].Item2;
             }
             Sort5.Items.Add("Previous position");
-            Sort1.SelectedIndex = 0;
-            Sort2.SelectedIndex = 0;
-            Sort3.SelectedIndex = 0;
-            Sort4.SelectedIndex = 0;
             Sort5.SelectedIndex = 0;
+            Reverse5.IsChecked = config.Sort.ReversePreviousPosition;
         }
 
-        public int ReturnSort1 { get; set; }
-        public bool ReturnReverse1 { get; set; }
-        public int ReturnSort2 { get; set; }
-        public bool ReturnReverse2 { get; set; }
-        public int ReturnSort3 { get; set; }
-        public bool ReturnReverse3 { get; set; }
-        public int ReturnSort4 { get; set; }
-        public bool ReturnReverse4 { get; set; }
-        public bool ReturnReverse5 { get; set; }
+        public (int, bool)[] Criteria()
+        {
+            return SortFields.Select((x, i) => (x.Key.SelectedIndex, x.Reverse.IsChecked.GetValueOrDefault())).ToArray();
+        }
+
+        public bool ReversePreviousPosition()
+        {
+            return Reverse5.IsChecked.GetValueOrDefault();
+        }
 
         private void CancelClick(object sender, RoutedEventArgs e)
         {
@@ -59,15 +60,6 @@ namespace WpfApp3
 
         private void SortClick(object sender, RoutedEventArgs e)
         {
-            this.ReturnSort1 = Sort1.SelectedIndex;
-            this.ReturnReverse1 = Reverse1.IsChecked.GetValueOrDefault();
-            this.ReturnSort2 = Sort2.SelectedIndex;
-            this.ReturnReverse2 = Reverse2.IsChecked.GetValueOrDefault();
-            this.ReturnSort3 = Sort3.SelectedIndex;
-            this.ReturnReverse3 = Reverse3.IsChecked.GetValueOrDefault();
-            this.ReturnSort4 = Sort4.SelectedIndex;
-            this.ReturnReverse4 = Reverse4.IsChecked.GetValueOrDefault();
-            this.ReturnReverse5 = Reverse5.IsChecked.GetValueOrDefault();
             this.DialogResult = true;
 
             Close();


### PR DESCRIPTION
So as I understand it, HCM lists the saves in the selected profile by last modified time (descending), and it lets you order (up/down) or sort your saves by swapping last modified times. This means new saves go at the top, and if you’re like me and want to keep everything sorted, you need to sort again.

I’m happy with how that all works, but given I always want to sort my saves by (level, difficulty, time), it’s annoying to have to choose those settings every time. This patch:

* makes the sort dialog save your settings to the HCMConfig (unless you cancel)
* makes the sort dialog load your settings from the HCMConfig when shown
* moves HCMConfig to its own file, to share it with SortSavesWindow
* replaces a bunch of code that was repeated four times with arrays/lists/loops